### PR TITLE
Remove libretro buildbot file.

### DIFF
--- a/.libretro-core-recipe
+++ b/.libretro-core-recipe
@@ -1,1 +1,0 @@
-higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master YES GENERIC GNUmakefile nSide compiler=g++ target=libretro binary=library


### PR DESCRIPTION
This causes this core to build constantly with the libretro buildbot.